### PR TITLE
Service principal fix and plugin name fixes

### DIFF
--- a/examples/data-sources/cop_example/data-source.tf
+++ b/examples/data-sources/cop_example/data-source.tf
@@ -6,23 +6,24 @@
 
 terraform {
   required_providers {
-    cop = {
-      source = "testTerraform.com/appd/cop"
+    observability = {
+      source = "testTerraform.com/appd/observability"
     }
   }
 }
 
-provider "cop" {
-  tenant      = "47a01df9-54a0-472b-96b8-7c8f64eb7cbf"
-  auth_method = "oauth"
-  url         = "https://alameda-c0-test-02.saas.appd-test.com"
+provider "observability" {
+  tenant="0eb4e853-34fb-4f77-b3fc-b9cd3b462366"
+  auth_method="service-principal"
+  url="https://aiops-dev.saas.appd-test.com"
+  secrets_file="/home/vdodin/aiops_secret.json"
 }
 
 
-data "cop_type" "ns" {
+data "observability_type" "ns" {
   type_name = "fmm:namespace"
 }
 
 output "myType" {
-  value = data.cop_type.ns
+  value = data.observability_type.ns
 }

--- a/examples/provider/provider_oauth.tf
+++ b/examples/provider/provider_oauth.tf
@@ -6,13 +6,13 @@
 
 terraform {
   required_providers {
-    cop = {
-      source = "testTerraform.com/appd/cop"
+    observability = {
+      source = "testTerraform.com/appd/observability"
     }
   }
 }
 
-provider "cop" {
+provider "observability" {
   tenant="47a01df9-54a0-472b-96b8-7c8f64eb7cbf"
   auth_method="oauth"
   url="https://alameda-c0-test-02.saas.appd-test.com"

--- a/examples/provider/provider_service_principal.tf
+++ b/examples/provider/provider_service_principal.tf
@@ -6,13 +6,13 @@
 
 terraform {
   required_providers {
-    cop = {
-      source = "testTerraform.com/appd/cop"
+    observability = {
+      source = "testTerraform.com/appd/observability"
     }
   }
 }
 
-provider "cop" {
+provider "observability" {
   tenant="47a01df9-54a0-472b-96b8-7c8f64eb7cbf"
   auth_method="service-principal"
   url="https://alameda-c0-test-02.saas.appd-test.com"

--- a/examples/resources/cop_example/resource.tf
+++ b/examples/resources/cop_example/resource.tf
@@ -6,19 +6,19 @@
 
 terraform {
   required_providers {
-    cop = {
-      source = "testTerraform.com/appd/cop"
+    observability = {
+      source = "testTerraform.com/appd/observability"
     }
   }
 }
 
-provider "cop" {
+provider "observability" {
   tenant      = "47a01df9-54a0-472b-96b8-7c8f64eb7cbf"
   auth_method = "oauth"
   url         = "https://alameda-c0-test-02.saas.appd-test.com"
 }
 
-resource "cop_object" "ns" {
+resource "observability_object" "ns" {
   type_name = "fmm:namespace"
   object_id = "aws"
   layer_type = "TENANT"

--- a/internal/api/objectapi.go
+++ b/internal/api/objectapi.go
@@ -34,10 +34,7 @@ func (ac *AppdClient) GetObject(fullyQualifiedTypeName, objectID, layerID, layer
 
 	req.Header.Add("Content-Type", contentType)
 	req.Header.Add("Accept", contentType)
-
-	if ac.AuthMethod == authMethodOAuth {
-		req.Header.Add("Authorization", "Bearer "+ac.Token)
-	}
+	req.Header.Add("Authorization", "Bearer "+ac.Token)
 
 	req.Header.Add("layer-id", layerID)
 	req.Header.Add("layer-type", layerType)

--- a/internal/api/typeapi.go
+++ b/internal/api/typeapi.go
@@ -27,10 +27,7 @@ func (ac *AppdClient) GetType(fullyQualifiedTypeName string) ([]byte, error) {
 
 	req.Header.Add("Content-Type", contentType)
 	req.Header.Add("Accept", contentType)
-
-	if ac.AuthMethod == authMethodOAuth {
-		req.Header.Add("Authorization", "Bearer "+ac.Token)
-	}
+	req.Header.Add("Authorization", "Bearer "+ac.Token)
 
 	// Do request
 	resp, err := ac.APIClient.Do(req)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -41,7 +41,7 @@ type COPProviderModel struct {
 }
 
 func (p *COPProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "cop"
+	resp.TypeName = "observability"
 	resp.Version = p.version
 }
 
@@ -49,7 +49,7 @@ func (p *COPProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"auth_method": schema.StringAttribute{
-				MarkdownDescription: "Authentication type selected for COP API requests. Possible values(oauth, headless, service-principal)",
+				MarkdownDescription: "Authentication type selected for observability API requests. Possible values(oauth, headless, service-principal)",
 				Required:            true,
 			},
 			"tenant": schema.StringAttribute{
@@ -92,7 +92,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if data.AuthMethod.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("auth_method"),
-			"Unknown cop API auth_method",
+			"Unknown observability API auth_method",
 			"Please make sure you configure the auth_method field",
 		)
 	}
@@ -100,7 +100,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if data.Tenant.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("tenant"),
-			"Unknown cop API tenant",
+			"Unknown observability API tenant",
 			"Please make sure you configure the tenant field",
 		)
 	}
@@ -108,7 +108,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if data.Username.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("username"),
-			"Unknown cop API username",
+			"Unknown observability API username",
 			"Please make sure you configure the username field",
 		)
 	}
@@ -116,7 +116,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if data.Password.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("password"),
-			"Unknown cop API password",
+			"Unknown observability API password",
 			"Please make sure you configure the password field",
 		)
 	}
@@ -124,7 +124,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if data.URL.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("url"),
-			"Unknown cop API url",
+			"Unknown observability API url",
 			"Please make sure you configure the url field",
 		)
 	}
@@ -132,7 +132,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if data.URL.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("secrets_file"),
-			"Unknown cop API secrets_file",
+			"Unknown observability API secrets_file",
 			"Please make sure you configure the secrets_file field",
 		)
 	}
@@ -186,7 +186,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if authMethod == "" {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("auth_method"),
-			"Missing cop API auth_method",
+			"Missing observability API auth_method",
 			"SET the COP_AUTH_METHOD env var or the config",
 		)
 		tflog.Error(ctx, "Missing or empty value for auth_method attribute")
@@ -197,7 +197,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		if url == "" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("url"),
-				"Missing cop API url",
+				"Missing observability API url",
 				"SET the COP_URL env var or the config",
 			)
 		}
@@ -205,7 +205,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		if tenantID == "" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("tenant"),
-				"Missing cop API tenant",
+				"Missing observability API tenant",
 				"SET the COP_TENANT env var or the config",
 			)
 		}
@@ -213,7 +213,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		if username == "" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("username"),
-				"Missing cop API username",
+				"Missing observability API username",
 				"SET the COP_USERNAME env var or the config",
 			)
 		}
@@ -221,7 +221,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		if password == "" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("password"),
-				"Missing cop API password",
+				"Missing observability API password",
 				"SET the COP_PASSWORD env var or the config",
 			)
 		}
@@ -229,7 +229,7 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		if secretsFile == "" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("secrets_file"),
-				"Missing cop API secrets_file",
+				"Missing observability API secrets_file",
 				"SET the SECRETS_FILE env var or the config",
 			)
 		}
@@ -253,10 +253,10 @@ func (p *COPProvider) Configure(ctx context.Context, req provider.ConfigureReque
 
 	err := appdClient.Login()
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Failed to authenticate to COP client: %s", err.Error()))
+		tflog.Error(ctx, fmt.Sprintf("Failed to authenticate to observability client: %s", err.Error()))
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Successful authentication to COP client using %s", appdClient.AuthMethod))
+	tflog.Debug(ctx, fmt.Sprintf("Successful authentication to observability client using %s", appdClient.AuthMethod))
 
 	// TODO change this to a real client
 	resp.DataSourceData = appdClient

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 		// TODO: Update this string with the published name of your provider.
 		// Also update the tfplugindocs generate command to either remove the
 		// -provider-name flag or set its value to the updated provider name.
-		Address: "testTerraform.com/appd/cop",
+		Address: "testTerraform.com/appd/observability",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
## Description

- Token was not populated in the bearer header for any other authentication methods besides OAuth 
- Binary name must match the provider name set in the Metadata method and all it's data sources and resources.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
